### PR TITLE
Left and Right margin fix in UI files

### DIFF
--- a/ui/choose.glade
+++ b/ui/choose.glade
@@ -63,7 +63,7 @@ Author: Antoine Bertin
           <object class="GtkBox" id="video_box">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="margin_start">6</property>
+            <property name="margin_left">6</property>
             <property name="margin_top">5</property>
             <property name="margin_bottom">5</property>
             <child>

--- a/ui/config.glade
+++ b/ui/config.glade
@@ -250,8 +250,8 @@ Author: Antoine Bertin
           <object class="GtkGrid" id="general_grid">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="margin_start">10</property>
-            <property name="margin_end">10</property>
+            <property name="margin_left">10</property>
+            <property name="margin_right">10</property>
             <property name="margin_top">15</property>
             <property name="margin_bottom">15</property>
             <property name="row_spacing">20</property>


### PR DESCRIPTION
I didn't know about this repository when I tried to configure Nautilus plugin for Nemo. Anyway there is a bug in UI files, when you downgraded the gtk requirement from 3.12 to 3.10, you didn't change the margin_start and margin_end to margin_left and margin_right. Due to this left and right margin doen't show in dialog boxes.

So this pull request just fix that. You can see the warning of margin_start and margin_end property not found when you run nemo through shell.
