### PR TITLE
fix translated messages installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -60,8 +60,9 @@ main() {
   cp -r ui /usr/share/nautilus-python/extensions/subliminal/
   for filepath in i18n/*.po; do
     filename=$(basename "$filepath")
-    install -d /usr/share/nautilus-python/extensions/subliminal/locale/${filename##*.}/LC_MESSAGES/
-    msgfmt ${filepath} -o /usr/share/nautilus-python/extensions/subliminal/locale/${filename##*.}/LC_MESSAGES/subliminal.mo
+    language=${filename%%.po}
+    install -d /usr/share/nautilus-python/extensions/subliminal/locale/${language}/LC_MESSAGES/
+    msgfmt ${filepath} -o /usr/share/nautilus-python/extensions/subliminal/locale/${language}/LC_MESSAGES/subliminal.mo
   done
 
   # Clean up


### PR DESCRIPTION
${filename##*.} translate to 'po' for all languages, given than it is a prefix substitution, whereas suffix substition is need here.

BTW, a simple installation-only Makefile and explicit documentation about required dependencies would probably be more explicit than an installation script than some users expect to run anywhere.